### PR TITLE
Add a null check to IconTabbedPageRenderer to avoid an exception when passing a NULL icon

### DIFF
--- a/src/FormsPlugin.Iconize.Droid/IconTabbedPageRenderer.cs
+++ b/src/FormsPlugin.Iconize.Droid/IconTabbedPageRenderer.cs
@@ -41,8 +41,11 @@ namespace FormsPlugin.Iconize.Droid
             {
                 foreach (var page in e.NewElement.Children)
                 {
-                    _icons.Add(page.Icon.File);
-                    page.Icon = null;
+                    if (page.Icon != null)
+                    {
+                        _icons.Add(page.Icon.File);
+                        page.Icon = null;
+                    }
                 }
             }
 


### PR DESCRIPTION
This pull request adds a null check to IconTabbedPageRenderer.

This null check prevents the application from crashing if you navigate to an IconTabbedPage with children ContentPage element that have a NULL icon.