### PR TITLE
using a TabbedPage thats already created throws an ArgumentOutOfRangeException on Android

### DIFF
--- a/src/FormsPlugin.Iconize.Droid/IconTabbedPageRenderer.cs
+++ b/src/FormsPlugin.Iconize.Droid/IconTabbedPageRenderer.cs
@@ -65,13 +65,18 @@ namespace FormsPlugin.Iconize.Droid
             {
                 var tab = tabLayout.GetTabAt(i);
 
-                var icon = Plugin.Iconize.Iconize.FindIconForKey(_icons[i]);
-                if (icon == null)
-                    continue;
+                if (_icons != null && i < _icons.Count)
+                {
+                    var iconKey = _icons[i];
 
-                var drawable = new IconDrawable(context, icon).Color(Color.White.ToAndroid()).SizeDp(20);
+                    var icon = Plugin.Iconize.Iconize.FindIconForKey(iconKey);
+                    if (icon == null)
+                        continue;
 
-                tab.SetIcon(drawable);
+                    var drawable = new IconDrawable(context, icon).Color(Color.White.ToAndroid()).SizeDp(20);
+
+                    tab.SetIcon(drawable);
+                }
             }
         }
     }

--- a/src/FormsPlugin.Iconize.Droid/IconTabbedPageRenderer.cs
+++ b/src/FormsPlugin.Iconize.Droid/IconTabbedPageRenderer.cs
@@ -41,8 +41,11 @@ namespace FormsPlugin.Iconize.Droid
             {
                 foreach (var page in e.NewElement.Children)
                 {
-                    _icons.Add(page.Icon.File);
-                    page.Icon = null;
+                    if (page.Icon != null)
+                    {
+                        _icons.Add(page.Icon.File);
+                        page.Icon = null;
+                    }
                 }
             }
 


### PR DESCRIPTION
the Android implementation of the IconTabbedRenderer sets the contents of the `_icons` list in the overridden OnElementChanged implementation.

the problem occurs if you have a TabbedPage thats already been created/drawn once and you push it back onto the navigation stack. 

this doesn't call OnElementChanged but it does call OnAttachedToWindow which expects to find some keys in the `_icons` list (but it's empty).