### PR TITLE
Parameterless constructor for IconNavigationPage

### DIFF
--- a/src/FormsPlugin.Iconize/IconNavigationPage.cs
+++ b/src/FormsPlugin.Iconize/IconNavigationPage.cs
@@ -14,12 +14,21 @@ namespace FormsPlugin.Iconize
         /// </summary>
         /// <param name="root">The root page.</param>
         public IconNavigationPage(Page root)
-            : base(root)
+            : this()
+        {
+            this.PushPage(root);
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IconNavigationPage" /> class.
+        /// </summary>
+        public IconNavigationPage()
         {
             Popped += OnNavigation;
             PoppedToRoot += OnNavigation;
             Pushed += OnNavigation;
         }
+
 
         /// <summary>
         /// Called when [navigation].

--- a/src/FormsPlugin.Iconize/IconNavigationPage.cs
+++ b/src/FormsPlugin.Iconize/IconNavigationPage.cs
@@ -14,9 +14,9 @@ namespace FormsPlugin.Iconize
         /// </summary>
         /// <param name="root">The root page.</param>
         public IconNavigationPage(Page root)
-            : this()
+            : base(root)
         {
-            this.PushPage(root);
+            InitListeners();
         }
         
         /// <summary>
@@ -24,11 +24,15 @@ namespace FormsPlugin.Iconize
         /// </summary>
         public IconNavigationPage()
         {
+            InitListeners();
+        }
+        
+        private void InitListeners()
+        {
             Popped += OnNavigation;
             PoppedToRoot += OnNavigation;
             Pushed += OnNavigation;
         }
-
 
         /// <summary>
         /// Called when [navigation].


### PR DESCRIPTION
Following the pattern of the base class, providing a parameterless constructor. This should allow the use in nav scenarios such as Prism, where you just declare the root page and have it constructed using DI.