### PR TITLE
remove ArgumentNullException in FindIconForKey

### DIFF
--- a/src/Plugin.Iconize.Shared/Iconize.cs
+++ b/src/Plugin.Iconize.Shared/Iconize.cs
@@ -96,7 +96,7 @@ namespace Plugin.Iconize
         public static IIcon FindIconForKey(String iconKey)
         {
             if (String.IsNullOrWhiteSpace(iconKey))
-                throw new ArgumentNullException(nameof(iconKey));
+                return null;
 
             return Modules.FirstOrDefault(x => x.Keys.Contains(iconKey))?.GetIcon(iconKey);
         }


### PR DESCRIPTION
I think it's better to remove it. Because sometime the element should be empty when the element is loading.