### PR TITLE
Fix android renderers

### DIFF
--- a/src/Plugin.Iconize.Android/Plugin.Iconize.Android.csproj
+++ b/src/Plugin.Iconize.Android/Plugin.Iconize.Android.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.3.5.253-pre5</Version>
+      <Version>2.4.0.269-pre2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\Plugin.Iconize.Shared\Plugin.Iconize.Shared.projitems" Label="Shared" />

--- a/src/Plugin.Iconize.Android/Renderers/IconButtonRenderer.cs
+++ b/src/Plugin.Iconize.Android/Renderers/IconButtonRenderer.cs
@@ -4,18 +4,25 @@ using Android.OS;
 using Plugin.Iconize;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
+#if USE_FASTRENDERERS
 using ButtonRenderer = Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer;
-
+#else
+using ButtonRenderer = Xamarin.Forms.Platform.Android.AppCompat.ButtonRenderer;
+#endif
 [assembly: ExportRenderer(typeof(IconButton), typeof(IconButtonRenderer))]
 namespace Plugin.Iconize
 {
     /// <summary>
     /// Defines the <see cref="IconButtonRenderer" /> renderer.
     /// </summary>
+#if USE_FASTRENDERERS
     /// <seealso cref="Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer" />
+#else
+    /// <seealso cref="Xamarin.Forms.Platform.Android.AppCompat.ButtonRenderer" />
+#endif
     public class IconButtonRenderer : ButtonRenderer
     {
-        #region Properties
+#region Properties
 
         /// <summary>
         /// Gets the button.
@@ -25,7 +32,7 @@ namespace Plugin.Iconize
         /// </value>
         private IconButton Button => Element as IconButton;
 
-        #endregion Properties
+#endregion Properties
 
         /// <summary>
         /// Called when [attached to window].
@@ -33,8 +40,11 @@ namespace Plugin.Iconize
         protected override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-
+#if USE_FASTRENDERERS
             TextChanged += OnTextChanged;
+#else
+            Control.TextChanged += OnTextChanged;
+#endif
         }
 
         /// <summary>
@@ -42,8 +52,11 @@ namespace Plugin.Iconize
         /// </summary>
         protected override void OnDetachedFromWindow()
         {
+#if USE_FASTRENDERERS
             TextChanged -= OnTextChanged;
-
+#else
+            Control.TextChanged -= OnTextChanged;
+#endif
             base.OnDetachedFromWindow();
         }
 
@@ -58,7 +71,11 @@ namespace Plugin.Iconize
             if (Button == null)
                 return;
 
+#if USE_FASTRENDERERS
             SetAllCaps(false);
+#else
+            Control.SetAllCaps(false);
+#endif
             if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
             {
                 this.SetBackground(null);
@@ -103,16 +120,29 @@ namespace Plugin.Iconize
         /// </summary>
         private void UpdateText()
         {
+#if USE_FASTRENDERERS
             TextChanged -= OnTextChanged;
+#else
+            Control.TextChanged -= OnTextChanged;
+#endif
 
             var icon = Iconize.FindIconForKey(Button.Text);
             if (icon != null)
             {
+#if USE_FASTRENDERERS
                 Text = $"{icon.Character}";
                 Typeface = Iconize.FindModuleOf(icon).ToTypeface(Context);
+#else
+                Control.Text = $"{icon.Character}";
+                Control.Typeface = Iconize.FindModuleOf(icon).ToTypeface(Context);
+#endif
             }
 
-            TextChanged += OnTextChanged;
+#if USE_FASTRENDERERS
+            TextChanged -= OnTextChanged;
+#else
+            Control.TextChanged -= OnTextChanged;
+#endif
         }
     }
 }

--- a/src/Plugin.Iconize.Android/Renderers/IconButtonRenderer.cs
+++ b/src/Plugin.Iconize.Android/Renderers/IconButtonRenderer.cs
@@ -22,7 +22,7 @@ namespace Plugin.Iconize
 #endif
     public class IconButtonRenderer : ButtonRenderer
     {
-#region Properties
+        #region Properties
 
         /// <summary>
         /// Gets the button.
@@ -32,7 +32,7 @@ namespace Plugin.Iconize
         /// </value>
         private IconButton Button => Element as IconButton;
 
-#endregion Properties
+        #endregion Properties
 
         /// <summary>
         /// Called when [attached to window].
@@ -139,9 +139,9 @@ namespace Plugin.Iconize
             }
 
 #if USE_FASTRENDERERS
-            TextChanged -= OnTextChanged;
+            TextChanged += OnTextChanged;
 #else
-            Control.TextChanged -= OnTextChanged;
+            Control.TextChanged += OnTextChanged;
 #endif
         }
     }

--- a/src/Plugin.Iconize.Android/Renderers/IconImageRenderer.cs
+++ b/src/Plugin.Iconize.Android/Renderers/IconImageRenderer.cs
@@ -3,7 +3,12 @@ using System.ComponentModel;
 using Plugin.Iconize;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
+#if USE_FASTRENDERERS
 using ImageRenderer = Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer;
+#else
+using ScaleType = Android.Widget.ImageView.ScaleType;
+using ImageRenderer = Xamarin.Forms.Platform.Android.ImageRenderer;
+#endif
 
 [assembly: ExportRenderer(typeof(IconImage), typeof(IconImageRenderer))]
 namespace Plugin.Iconize
@@ -14,7 +19,7 @@ namespace Plugin.Iconize
     /// <seealso cref="Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer" />
     public class IconImageRenderer : ImageRenderer
     {
-        #region Properties
+#region Properties
 
         /// <summary>
         /// Gets the image.
@@ -24,7 +29,7 @@ namespace Plugin.Iconize
         /// </value>
         private IconImage Image { get; set; }
 
-        #endregion Properties
+#endregion Properties
 
         /// <summary>
         /// Raises the <see cref="E:ElementChanged" /> event.
@@ -72,7 +77,11 @@ namespace Plugin.Iconize
             var icon = Iconize.FindIconForKey(Image.Icon);
             if (icon == null)
             {
+#if USE_FASTRENDERERS
                 SetImageResource(Android.Resource.Color.Transparent);
+#else
+                Control.SetImageResource(Android.Resource.Color.Transparent);
+#endif
                 return;
             }
 
@@ -80,8 +89,13 @@ namespace Plugin.Iconize
 
             var drawable = new IconDrawable(Context, icon).Color(Image.IconColor.ToAndroid())
                                                           .SizeDp((Int32)iconSize);
+#if USE_FASTRENDERERS
             SetScaleType(Image.IconSize > 0 ? ScaleType.Center : ScaleType.FitCenter);
             SetImageDrawable(drawable);
+#else
+            Control.SetScaleType(Image.IconSize > 0 ? ScaleType.Center : ScaleType.FitCenter);
+            Control.SetImageDrawable(drawable);
+#endif
         }
     }
 }

--- a/src/Plugin.Iconize.Android/Renderers/IconImageRenderer.cs
+++ b/src/Plugin.Iconize.Android/Renderers/IconImageRenderer.cs
@@ -23,7 +23,7 @@ namespace Plugin.Iconize
 #endif
     public class IconImageRenderer : ImageRenderer
     {
-#region Properties
+        #region Properties
 
         /// <summary>
         /// Gets the image.
@@ -33,7 +33,7 @@ namespace Plugin.Iconize
         /// </value>
         private IconImage Image { get; set; }
 
-#endregion Properties
+        #endregion Properties
 
         /// <summary>
         /// Raises the <see cref="E:ElementChanged" /> event.

--- a/src/Plugin.Iconize.Android/Renderers/IconImageRenderer.cs
+++ b/src/Plugin.Iconize.Android/Renderers/IconImageRenderer.cs
@@ -16,7 +16,11 @@ namespace Plugin.Iconize
     /// <summary>
     /// Defines the <see cref="IconImageRenderer" /> renderer.
     /// </summary>
+#if USE_FASTRENDERERS
     /// <seealso cref="Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer" />
+#else
+    /// <seealso cref="Xamarin.Forms.Platform.Android.ImageRenderer" />
+#endif
     public class IconImageRenderer : ImageRenderer
     {
 #region Properties

--- a/src/Plugin.Iconize.Android/Renderers/IconLabelRenderer.cs
+++ b/src/Plugin.Iconize.Android/Renderers/IconLabelRenderer.cs
@@ -3,7 +3,11 @@ using System.ComponentModel;
 using Plugin.Iconize;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
+#if USE_FASTRENDERERS
 using LabelRenderer = Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer;
+#else
+using LabelRenderer = Xamarin.Forms.Platform.Android.LabelRenderer;
+#endif
 
 [assembly: ExportRenderer(typeof(IconLabel), typeof(IconLabelRenderer))]
 namespace Plugin.Iconize
@@ -11,7 +15,11 @@ namespace Plugin.Iconize
     /// <summary>
     /// Defines the <see cref="IconLabelRenderer" /> renderer.
     /// </summary>
+#if USE_FASTRENDERERS
     /// <seealso cref="Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer" />
+#else
+    /// <seealso cref="Xamarin.Forms.Platform.Android.LabelRenderer" />
+#endif
     public class IconLabelRenderer : LabelRenderer
     {
         #region Properties
@@ -32,8 +40,11 @@ namespace Plugin.Iconize
         protected override void OnAttachedToWindow()
         {
             base.OnAttachedToWindow();
-
+#if USE_FASTRENDERERS
             TextChanged += OnTextChanged;
+#else
+            Control.TextChanged += OnTextChanged;
+#endif
         }
 
         /// <summary>
@@ -41,8 +52,11 @@ namespace Plugin.Iconize
         /// </summary>
         protected override void OnDetachedFromWindow()
         {
+#if USE_FASTRENDERERS
             TextChanged -= OnTextChanged;
-
+#else
+            Control.TextChanged -= OnTextChanged;
+#endif
             base.OnDetachedFromWindow();
         }
 
@@ -96,16 +110,28 @@ namespace Plugin.Iconize
         /// </summary>
         private void UpdateText()
         {
+#if USE_FASTRENDERERS
             TextChanged -= OnTextChanged;
+#else
+            Control.TextChanged -= OnTextChanged;
+#endif
 
             var icon = Iconize.FindIconForKey(Label.Text);
             if (icon != null)
             {
+#if USE_FASTRENDERERS
                 Text = $"{icon.Character}";
                 Typeface = Iconize.FindModuleOf(icon).ToTypeface(Context);
+#else
+                Control.Text = $"{icon.Character}";
+                Control.Typeface = Iconize.FindModuleOf(icon).ToTypeface(Context);
+#endif
             }
-
+#if USE_FASTRENDERERS
             TextChanged += OnTextChanged;
+#else
+            Control.TextChanged += OnTextChanged;
+#endif
         }
     }
 }

--- a/src/Plugin.Iconize.UWP/Plugin.Iconize.UWP.csproj
+++ b/src/Plugin.Iconize.UWP/Plugin.Iconize.UWP.csproj
@@ -57,7 +57,7 @@
       <Version>1.58.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.3.5.253-pre5</Version>
+      <Version>2.4.0.269-pre2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\Plugin.Iconize.Shared\Plugin.Iconize.Shared.projitems" Label="Shared" />

--- a/src/Plugin.Iconize.iOS/Plugin.Iconize.iOS.csproj
+++ b/src/Plugin.Iconize.iOS/Plugin.Iconize.iOS.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.3.5.253-pre5</Version>
+      <Version>2.4.0.269-pre2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\Plugin.Iconize.Shared\Plugin.Iconize.Shared.projitems" Label="Shared" />

--- a/src/Plugin.Iconize/Plugin.Iconize.csproj
+++ b/src/Plugin.Iconize/Plugin.Iconize.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.3.5.253-pre5" />
+    <PackageReference Include="Xamarin.Forms" Version="2.4.0.269-pre2" />
   </ItemGroup>
 
   <Import Project="..\Plugin.Iconize.Shared\Plugin.Iconize.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
Hello Jeremy,

Since in the latest pre-release of xamarin.forms all the fastrenderers are marked as internal sealed, I've introduced a compile time flag called `USE_FASTRENDERERS` to allow future testing with the FastRenderes while mantaining the compatibility with the "old" renderers. 

This fixes the issue #30 

Cheers,
Riccardo