### PR TITLE
Fix for #89; IconDrawable intrinsic width/height mixup

### DIFF
--- a/src/Plugin.Iconize/Platform/Android/IconDrawable.cs
+++ b/src/Plugin.Iconize/Platform/Android/IconDrawable.cs
@@ -58,7 +58,7 @@ namespace Plugin.Iconize
         /// </para>
         /// </remarks>
         /// <since version="Added in API level 1" />
-		public override Int32 IntrinsicHeight => Bounds.Width();
+		public override Int32 IntrinsicHeight => Bounds.Height();
 
         /// <summary>
         /// Return the intrinsic width of the underlying drawable object.
@@ -77,7 +77,7 @@ namespace Plugin.Iconize
         /// </para>
         /// </remarks>
         /// <since version="Added in API level 1" />
-		public override Int32 IntrinsicWidth => Bounds.Height();
+		public override Int32 IntrinsicWidth => Bounds.Width();
 
         /// <summary>
         /// Indicates whether this view will change its appearance based on state.


### PR DESCRIPTION
In IconDrawable.cs from my last pull request; IntrinsicWidth was set to Bounds.Height() instead of Bounds.Width() and vise-versa for InstrinsicHeight.