### PR TITLE
UWP - fixed NullReferenceException in IconNavigationPageRenderer

### DIFF
--- a/src/Plugin.Iconize/Platform/UWP/Renderers/IconNavigationPageRenderer.cs
+++ b/src/Plugin.Iconize/Platform/UWP/Renderers/IconNavigationPageRenderer.cs
@@ -62,6 +62,9 @@ namespace Plugin.Iconize
         /// </summary>
         private async void UpdateToolbarItems()
         {
+            if (Element == null)
+                return;
+
             var platform = Element.Platform;
             FieldInfo fInfo = typeof(Platform).GetField("_container", BindingFlags.NonPublic | BindingFlags.Instance);
             Canvas canvas = fInfo.GetValue(platform) as Canvas;


### PR DESCRIPTION
Might be a small fix, but without it Iconize is unusable on UWP :-|