### PR TITLE
Fix FontAwesome Pro font names

### DIFF
--- a/src/Fonts/Plugin.Iconize.FontAwesomePro/FontAwesomeProBrandsModule.cs
+++ b/src/Fonts/Plugin.Iconize.FontAwesomePro/FontAwesomeProBrandsModule.cs
@@ -10,7 +10,7 @@
         /// Initializes a new instance of the <see cref="FontAwesomeProBrandsModule" /> class.
         /// </summary>
         public FontAwesomeProBrandsModule()
-            : base("Font Awesome 5 Pro Brands", "FontAwesome5ProBrandsRegular", "iconize-fontawesome-pro-brands.ttf", FontAwesomeProCollection.BrandIcons)
+            : base("Font Awesome 5 Pro Brands", "FontAwesome5ProBrands-Regular", "iconize-fontawesome-pro-brands.ttf", FontAwesomeProCollection.BrandIcons)
         {
             // Intentionally left blank
         }

--- a/src/Fonts/Plugin.Iconize.FontAwesomePro/FontAwesomeProLightModule.cs
+++ b/src/Fonts/Plugin.Iconize.FontAwesomePro/FontAwesomeProLightModule.cs
@@ -10,7 +10,7 @@
         /// Initializes a new instance of the <see cref="FontAwesomeProLightModule" /> class.
         /// </summary>
         public FontAwesomeProLightModule()
-            : base("Font Awesome 5 Pro Light", "FontAwesome5ProLight", "iconize-fontawesome-pro-light.ttf", FontAwesomeProCollection.LightIcons)
+            : base("Font Awesome 5 Pro Light", "FontAwesome5Pro-Light", "iconize-fontawesome-pro-light.ttf", FontAwesomeProCollection.LightIcons)
         {
             // Intentionally left blank
         }

--- a/src/Fonts/Plugin.Iconize.FontAwesomePro/FontAwesomeProRegularModule.cs
+++ b/src/Fonts/Plugin.Iconize.FontAwesomePro/FontAwesomeProRegularModule.cs
@@ -10,7 +10,7 @@
         /// Initializes a new instance of the <see cref="FontAwesomeProRegularModule" /> class.
         /// </summary>
         public FontAwesomeProRegularModule()
-            : base("Font Awesome 5 Pro Regular", "FontAwesome5ProRegular", "iconize-fontawesome-pro-regular.ttf", FontAwesomeProCollection.RegularIcons)
+            : base("Font Awesome 5 Pro Regular", "FontAwesome5Pro-Regular", "iconize-fontawesome-pro-regular.ttf", FontAwesomeProCollection.RegularIcons)
         {
             // Intentionally left blank
         }

--- a/src/Fonts/Plugin.Iconize.FontAwesomePro/FontAwesomeProSolidModule.cs
+++ b/src/Fonts/Plugin.Iconize.FontAwesomePro/FontAwesomeProSolidModule.cs
@@ -10,7 +10,7 @@
         /// Initializes a new instance of the <see cref="FontAwesomeProSolidModule" /> class.
         /// </summary>
         public FontAwesomeProSolidModule()
-            : base("Font Awesome 5 Pro Solid", "FontAwesome5ProSolid", "iconize-fontawesome-pro-solid.ttf", FontAwesomeProCollection.SolidIcons)
+            : base("Font Awesome 5 Pro Solid", "FontAwesome5Pro-Solid", "iconize-fontawesome-pro-solid.ttf", FontAwesomeProCollection.SolidIcons)
         {
             // Intentionally left blank
         }


### PR DESCRIPTION
This is the same fix as #127 but for the FontAwesome Pro modules.