### PR TITLE
Fix FontAwesome solid on UWP.

### DIFF
--- a/src/Plugin.Iconize/Platform/UWP/PlatformExtensions.cs
+++ b/src/Plugin.Iconize/Platform/UWP/PlatformExtensions.cs
@@ -31,7 +31,7 @@ namespace Plugin.Iconize
             var moduleType = module.GetType();
             if (!FontCache.ContainsKey(moduleType))
             {
-				FontCache.Add(moduleType, new FontFamily($"ms-appx:///{moduleType.GetTypeInfo().Assembly.GetName().Name}/{module.FontPath}#{module.FontFamily.Replace(" Regular","")}"));
+				FontCache.Add(moduleType, new FontFamily($"ms-appx:///{moduleType.GetTypeInfo().Assembly.GetName().Name}/{module.FontPath}#{module.FontFamily.Replace(" Regular","").Replace(" Solid","")}"));
             }
             return FontCache[moduleType];
         }


### PR DESCRIPTION
Like for FontAwesome Regular font, remove the Solid suffix.

The issue is mentionned in this comment https://github.com/FortAwesome/Font-Awesome/issues/12262#issuecomment-391376480